### PR TITLE
Minor tweaks field name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/twitter/cli-guide.js/issues"
   },
   "homepage": "https://github.com/twitter/cli-guide.js",
-  "dependencies" : {
+  "devDependencies" : {
     "gulp":            "3.8.11",
     "gulp-jsmin":      "0.1.5",
     "gulp-rename":     "1.2.2",


### PR DESCRIPTION
Hi,

In this case, you may should use `devDependencies` field in package.json.

> If someone is planning on downloading and using your module in their program, then they probably don't want or need to download and build the external test or documentation framework that you use.

See also:
- https://docs.npmjs.com/files/package.json#dependencies
- https://docs.npmjs.com/files/package.json#devdependencies

Thanks!
